### PR TITLE
add allowBlobPublicAccessProperty

### DIFF
--- a/proj12-blob/main.bicep
+++ b/proj12-blob/main.bicep
@@ -18,6 +18,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   sku: {
     name: 'Standard_LRS'
   }
+  properties: {
+    allowBlobPublicAccess: true
+  }
 }
 
 // Blobサービス

--- a/proj17-uploader/main.bicep
+++ b/proj17-uploader/main.bicep
@@ -99,6 +99,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   sku: {
     name: 'Standard_LRS'
   }
+  properties: {
+    allowBlobPublicAccess: true
+  }
 }
 
 // Blobサービス

--- a/proj18-funcapp/main.bicep
+++ b/proj18-funcapp/main.bicep
@@ -24,7 +24,10 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   sku: {
     name: 'Standard_LRS'
   }
-
+  properties: {
+    allowBlobPublicAccess: true
+  }
+  
   // Blobサービス
   resource blobService 'blobServices' = {
     name: 'default'


### PR DESCRIPTION
ストレージアカウントの匿名アクセスが既定値でfalseになったために、BlobコンテナのpublicAccessをBlobに設定するところでエラーになりリソースのデプロイに失敗します。
ストレージアカウントの設定にallowBlobPublicAccess: trueを書き加えました。